### PR TITLE
Add HTML Class to Dependencies Success Message

### DIFF
--- a/lib/iruby/dependencies.rb
+++ b/lib/iruby/dependencies.rb
@@ -46,7 +46,7 @@ module IRuby
 
     def to_html
       <<-HTML
-        <div style='background: rgba(0,255,0,0.3);
+        <div class="stdsuccess" style='background: rgba(0,255,0,0.3);
                     font-family: monospace;
                     padding: 5px;'>
           <b>Dependencies successfully installed!</b>


### PR DESCRIPTION
To fix a styling bug on notebooks that inject these statements on NBG and also in Jupyter or standalone if you add want to style it.